### PR TITLE
Fix > TFE Run > Plugin > duplicate example

### DIFF
--- a/docs/tables/tfe_run.md
+++ b/docs/tables/tfe_run.md
@@ -34,21 +34,6 @@ where
   and created_at > current_timestamp - interval '24 hrs'
 ```
 
-### Runs that errored in the last 24 hrs
-
-```sql
-select
-  id,
-  created_at,
-  status
-from
-  tfe_run
-where
-  workspace_id = 'ws-ocKJU1ouZNZWZoUx'
-  and status = 'errored'
-  and created_at > current_timestamp - interval '24 hrs'
-```
-
 ### Which users created the most runs?
 
 ```sql


### PR DESCRIPTION
Removed a duplicate example `Runs that errored in the last 24 hrs` from the tfe_run table. 
