### PR TITLE
Fix `vcs_repo` column in table `tfe_workspace`. Closes #18

### DIFF
--- a/docs/tables/tfe_workspace.md
+++ b/docs/tables/tfe_workspace.md
@@ -38,7 +38,5 @@ select
   vcs_repo ->> 'RepositoryHTTPURL' as vcs_repo_repository_http_url,
   vcs_repo ->> 'ServiceProvider' as vcs_repo_service_provider
 from
-  tfe_workspace
-where
-  vcs_repo is not null;
+  tfe_workspace;
 ```

--- a/docs/tables/tfe_workspace.md
+++ b/docs/tables/tfe_workspace.md
@@ -23,3 +23,22 @@ from
 where
   id = 'ws-ocYGM1ouZNZWZoUy';
 ```
+
+### Get VCS repository settings for workspaces
+
+```sql
+select
+  id,
+  name,
+  vcs_repo ->> 'Identifier' as vcs_repo_identifier,
+  vcs_repo ->> 'OAuthTokenID' as vcs_repo_oauth_token_id,
+  vcs_repo ->> 'Branch' as vcs_repo_branch,
+  vcs_repo ->> 'DisplayIdentifier' as vcs_repo_display_identifier,
+  vcs_repo ->> 'IngressSubmodules' as vcs_repo_ingress_submodules,
+  vcs_repo ->> 'RepositoryHTTPURL' as vcs_repo_repository_http_url,
+  vcs_repo ->> 'ServiceProvider' as vcs_repo_service_provider
+from
+  tfe_workspace
+where
+  vcs_repo is not null;
+```

--- a/tfe/table_tfe_workspace.go
+++ b/tfe/table_tfe_workspace.go
@@ -59,7 +59,7 @@ func tableTfeWorkspace(ctx context.Context) *plugin.Table {
 			{Name: "terraform_version", Type: proto.ColumnType_STRING, Description: "The version of Terraform to use for this workspace. Upon creating a workspace, the latest version is selected unless otherwise specified (e.g. 0.11.1)."},
 			{Name: "trigger_prefixes", Type: proto.ColumnType_JSON, Description: "List of repository-root-relative paths which should be tracked for changes, in addition to the working directory."},
 			{Name: "updated_at", Type: proto.ColumnType_TIMESTAMP, Description: "When the workspace was last updated."},
-			{Name: "vcs_repo", Type: proto.ColumnType_JSON, Description: "Settings for the workspace's VCS repository. If omitted, the workspace is created without a VCS repo."},
+			{Name: "vcs_repo", Type: proto.ColumnType_JSON, Description: "Settings for the workspace's VCS repository. If omitted, the workspace is created without a VCS repo.", Transform: transform.FromField("VCSRepo")},
 			{Name: "working_directory", Type: proto.ColumnType_STRING, Description: "A relative path that Terraform will execute within. This defaults to the root of your repository and is typically set to a subdirectory matching the environment when multiple environments exist within the same repository."},
 		},
 	}


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  id,
  name,
  vcs_repo ->> 'Identifier' as vcs_repo_identifier,
  vcs_repo ->> 'OAuthTokenID' as vcs_repo_oauth_token_id,
  vcs_repo ->> 'Branch' as vcs_repo_branch,
  vcs_repo ->> 'DisplayIdentifier' as vcs_repo_display_identifier,
  vcs_repo ->> 'IngressSubmodules' as vcs_repo_ingress_submodules,
  vcs_repo ->> 'RepositoryHTTPURL' as vcs_repo_repository_http_url,
  vcs_repo ->> 'ServiceProvider' as vcs_repo_service_provider
from
  tfe_workspace
where
  vcs_repo is not null;
+---------------------+--------+---------------------+-------------------------+-----------------+-----------------------------+-----------------------------+--------------------------------------+---------------------------+
| id                  | name   | vcs_repo_identifier | vcs_repo_oauth_token_id | vcs_repo_branch | vcs_repo_display_identifier | vcs_repo_ingress_submodules | vcs_repo_repository_http_url         | vcs_repo_service_provider |
+---------------------+--------+---------------------+-------------------------+-----------------+-----------------------------+-----------------------------+--------------------------------------+---------------------------+
| ws-ohtjHiLgx2g8ubax | burger | org123/burger   |                         |                 | org123/burger           | false                       | https://github.com/org123/burger | github_app                |
+---------------------+--------+---------------------+-------------------------+-----------------+-----------------------------+-----------------------------+--------------------------------------+---------------------------+
```
</details>
